### PR TITLE
Upgrade SPI version, remove methods with default implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ ext {
     license = 'Apache 2'
 
     /* Dependencies */
-    trellisApiVersion = '0.1.0'
-    trellisSpiVersion = '0.1.0'
+    trellisApiVersion = '0.1.1'
+    trellisSpiVersion = '0.1.4'
     trellisVocabularyVersion = '0.1.0'
     commonsRdfVersion = '0.3.0-incubating'
     cassandraDriverVersion = '3.3.0'

--- a/src/main/java/org/trellisldp/drastic/DrasticResourceService.java
+++ b/src/main/java/org/trellisldp/drastic/DrasticResourceService.java
@@ -4,85 +4,60 @@
 package org.trellisldp.drastic;
 
 import java.time.Instant;
-import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.Quad;
-import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.Triple;
 import org.trellisldp.api.Resource;
 import org.trellisldp.spi.ResourceService;
 
+/**
+ * @author ajs6f
+ */
 public class DrasticResourceService implements ResourceService {
 
-	@Override
-	public Optional<Resource> get(IRI identifier) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Optional<Resource> get(final IRI identifier) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public Optional<Resource> get(IRI identifier, Instant time) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Optional<Resource> get(final IRI identifier, final Instant time) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public Boolean put(IRI identifier, Dataset dataset) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Boolean put(final IRI identifier, final Dataset dataset) {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public Optional<IRI> getContainer(IRI identifier) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Supplier<String> getIdentifierSupplier() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
-	@Override
-	public Stream<IRI> compact(IRI identifier, Instant from, Instant until) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Stream<IRI> compact(final IRI identifier, final Instant from, final Instant until) {
+        // it is not necessary to implement this
+        throw new UnsupportedOperationException("Resource listing not supported");
+    }
 
-	@Override
-	public Stream<IRI> purge(IRI identifier) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public Stream<IRI> purge(final IRI identifier) {
+        // it is not necessary to implement this
+        throw new UnsupportedOperationException("Resource listing not supported");
+    }
 
-	@Override
-	public Stream<Triple> list(String partition) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public RDFTerm skolemize(RDFTerm term) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public RDFTerm unskolemize(RDFTerm term) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public Stream<Quad> export(String partition, Collection<IRI> graphNames) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public Supplier<String> getIdentifierSupplier() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
+    @Override
+    public Stream<? extends Triple> list(final String partition) {
+        // it is not necessary to implement this
+        throw new UnsupportedOperationException("Resource listing not supported");
+    }
 }


### PR DESCRIPTION
This updates the trellis-spi and trellis-api versions and removes any methods with default implementations. In addition, I have marked a few methods as unnecessary to implement (`list`, `compact` and `purge`) -- there is absolutely no need to implement them at this stage.

I also added a `final` keyword so that the code minimally builds.