### PR TITLE
Update to latest trellis-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,7 @@ ext {
     license = 'Apache 2'
 
     /* Dependencies */
-    trellisApiVersion = '0.1.1'
-    trellisSpiVersion = '0.1.4'
+    trellisApiVersion = '0.3.0'
     trellisVocabularyVersion = '0.1.0'
     commonsRdfVersion = '0.3.0-incubating'
     cassandraDriverVersion = '3.3.0'
@@ -53,7 +52,6 @@ configurations {
 dependencies {
     api group: 'org.apache.commons', name: 'commons-rdf-api', version: commonsRdfVersion
     api group: 'org.trellisldp', name: 'trellis-api', version: trellisApiVersion
-    api group: 'org.trellisldp', name: 'trellis-spi', version: trellisSpiVersion
 
     implementation group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     implementation group: 'org.trellisldp', name: 'trellis-vocabulary', version: trellisVocabularyVersion

--- a/src/main/java/org/trellisldp/drastic/DrasticResourceService.java
+++ b/src/main/java/org/trellisldp/drastic/DrasticResourceService.java
@@ -12,7 +12,7 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Triple;
 import org.trellisldp.api.Resource;
-import org.trellisldp.spi.ResourceService;
+import org.trellisldp.api.ResourceService;
 
 /**
  * @author ajs6f
@@ -56,7 +56,7 @@ public class DrasticResourceService implements ResourceService {
     }
 
     @Override
-    public Stream<? extends Triple> list(final String partition) {
+    public Stream<? extends Triple> scan(final String partition) {
         // it is not necessary to implement this
         throw new UnsupportedOperationException("Resource listing not supported");
     }


### PR DESCRIPTION
The `org.trellisldp.spi` package has been consolidated into the `org.trellisldp.api` package. This updates to the latest version of the Trellis API.